### PR TITLE
Fix CHANGELOG filename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# ChangeLog
+# Changelog
 
 * (4 September 2014). Updating the `README` with Windows symbolic link instructions.
 * (3 September 2014). Updating the `README` to describe how to install the Boilerplate.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A standardized, organized, object-oriented foundation for building high-quality 
 The WordPress Plugin Boilerplate includes the following files:
 
 * `.gitignore`. Used to exclude certain files from the repository.
-* `ChangeLog.md`. The list of changes to the core project.
+* `CHANGELOG.md`. The list of changes to the core project.
 * `README.md`. The file that you’re currently reading.
 * A `plugin-name` subdirectory that contains the source code - a fully executable WordPress plugin.
 


### PR DESCRIPTION
No idea why the filename was snaked cased as `ChangeLog.md` but the convention is to uppercase all files like `README`, `LICENSE`, `CONTRIBUTING`, `CHANGELOG`, etc.

Ref: http://keepachangelog.com/ and all over [GitHub](https://github.com/search?utf8=%E2%9C%93&q=CHANGELOG+language%3AMarkdown+extension%3Amd&type=Code&ref=advsearch&l=Markdown).