### PR TITLE
Function docs should be @param not @var.

### DIFF
--- a/plugin-name/trunk/admin/class-plugin-name-admin.php
+++ b/plugin-name/trunk/admin/class-plugin-name-admin.php
@@ -44,8 +44,8 @@ class Plugin_Name_Admin {
 	 * Initialize the class and set its properties.
 	 *
 	 * @since    1.0.0
-	 * @var      string    $plugin_name       The name of this plugin.
-	 * @var      string    $version    The version of this plugin.
+	 * @param      string    $plugin_name       The name of this plugin.
+	 * @param      string    $version    The version of this plugin.
 	 */
 	public function __construct( $plugin_name, $version ) {
 

--- a/plugin-name/trunk/includes/class-plugin-name-loader.php
+++ b/plugin-name/trunk/includes/class-plugin-name-loader.php
@@ -57,11 +57,11 @@ class Plugin_Name_Loader {
 	 * Add a new action to the collection to be registered with WordPress.
 	 *
 	 * @since    1.0.0
-	 * @var      string               $hook             The name of the WordPress action that is being registered.
-	 * @var      object               $component        A reference to the instance of the object on which the action is defined.
-	 * @var      string               $callback         The name of the function definition on the $component.
-	 * @var      int      Optional    $priority         The priority at which the function should be fired.
-	 * @var      int      Optional    $accepted_args    The number of arguments that should be passed to the $callback.
+	 * @param      string               $hook             The name of the WordPress action that is being registered.
+	 * @param      object               $component        A reference to the instance of the object on which the action is defined.
+	 * @param      string               $callback         The name of the function definition on the $component.
+	 * @param      int      Optional    $priority         The priority at which the function should be fired.
+	 * @param      int      Optional    $accepted_args    The number of arguments that should be passed to the $callback.
 	 */
 	public function add_action( $hook, $component, $callback, $priority = 10, $accepted_args = 1 ) {
 		$this->actions = $this->add( $this->actions, $hook, $component, $callback, $priority, $accepted_args );
@@ -71,11 +71,11 @@ class Plugin_Name_Loader {
 	 * Add a new filter to the collection to be registered with WordPress.
 	 *
 	 * @since    1.0.0
-	 * @var      string               $hook             The name of the WordPress filter that is being registered.
-	 * @var      object               $component        A reference to the instance of the object on which the filter is defined.
-	 * @var      string               $callback         The name of the function definition on the $component.
-	 * @var      int      Optional    $priority         The priority at which the function should be fired.
-	 * @var      int      Optional    $accepted_args    The number of arguments that should be passed to the $callback.
+	 * @param      string               $hook             The name of the WordPress filter that is being registered.
+	 * @param      object               $component        A reference to the instance of the object on which the filter is defined.
+	 * @param      string               $callback         The name of the function definition on the $component.
+	 * @param      int      Optional    $priority         The priority at which the function should be fired.
+	 * @param      int      Optional    $accepted_args    The number of arguments that should be passed to the $callback.
 	 */
 	public function add_filter( $hook, $component, $callback, $priority = 10, $accepted_args = 1 ) {
 		$this->filters = $this->add( $this->filters, $hook, $component, $callback, $priority, $accepted_args );
@@ -87,12 +87,12 @@ class Plugin_Name_Loader {
 	 *
 	 * @since    1.0.0
 	 * @access   private
-	 * @var      array                $hooks            The collection of hooks that is being registered (that is, actions or filters).
-	 * @var      string               $hook             The name of the WordPress filter that is being registered.
-	 * @var      object               $component        A reference to the instance of the object on which the filter is defined.
-	 * @var      string               $callback         The name of the function definition on the $component.
-	 * @var      int      Optional    $priority         The priority at which the function should be fired.
-	 * @var      int      Optional    $accepted_args    The number of arguments that should be passed to the $callback.
+	 * @param      array                $hooks            The collection of hooks that is being registered (that is, actions or filters).
+	 * @param      string               $hook             The name of the WordPress filter that is being registered.
+	 * @param      object               $component        A reference to the instance of the object on which the filter is defined.
+	 * @param      string               $callback         The name of the function definition on the $component.
+	 * @param      int      Optional    $priority         The priority at which the function should be fired.
+	 * @param      int      Optional    $accepted_args    The number of arguments that should be passed to the $callback.
 	 * @return   type                                   The collection of actions and filters registered with WordPress.
 	 */
 	private function add( $hooks, $hook, $component, $callback, $priority, $accepted_args ) {

--- a/plugin-name/trunk/public/class-plugin-name-public.php
+++ b/plugin-name/trunk/public/class-plugin-name-public.php
@@ -44,8 +44,8 @@ class Plugin_Name_Public {
 	 * Initialize the class and set its properties.
 	 *
 	 * @since    1.0.0
-	 * @var      string    $plugin_name       The name of the plugin.
-	 * @var      string    $version    The version of this plugin.
+	 * @param      string    $plugin_name       The name of the plugin.
+	 * @param      string    $version    The version of this plugin.
 	 */
 	public function __construct( $plugin_name, $version ) {
 


### PR DESCRIPTION
Parameter documentation for functions should use @param, not @var. 

@param is for function parameters: http://www.phpdoc.org/docs/latest/references/phpdoc/tags/param.html

@var is for class variables: http://www.phpdoc.org/docs/latest/references/phpdoc/tags/var.html